### PR TITLE
Fix bug with missing column value

### DIFF
--- a/app/wama.core/Migrations/20170220045410_remove lastupdatedon.Designer.cs
+++ b/app/wama.core/Migrations/20170220045410_remove lastupdatedon.Designer.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using WAMA.Core.Models;
+using WAMA.Core.Models.DTOs;
+
+namespace WAMA.Core.Migrations
+{
+    [DbContext(typeof(WamaDbContext))]
+    [Migration("20170220045410_remove lastupdatedon")]
+    partial class removelastupdatedon
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.0-rtm-22752")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.Certification", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTimeOffset>("CertifiedOn");
+
+                    b.Property<DateTimeOffset>("ExpiresOn");
+
+                    b.Property<string>("MemberId");
+
+                    b.Property<int>("Type");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.HasKey("__ID");
+
+                    b.HasIndex("MemberId");
+
+                    b.ToTable("Certifications");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.CheckInActivity", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTimeOffset>("CheckInDateTime");
+
+                    b.Property<bool>("IsCheckedIn");
+
+                    b.Property<string>("MemberId");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.HasKey("__ID");
+
+                    b.HasIndex("MemberId");
+
+                    b.ToTable("CheckInActivities");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.LogInCredential", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("MemberId");
+
+                    b.Property<string>("Password");
+
+                    b.Property<bool>("RequiresPassword");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.HasKey("__ID");
+
+                    b.HasIndex("MemberId")
+                        .IsUnique();
+
+                    b.ToTable("LogInCredentials");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.UserAccount", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("AccountType");
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<int>("Gender");
+
+                    b.Property<bool>("HasBeenApproved");
+
+                    b.Property<int>("InstitutionAffiliation");
+
+                    b.Property<bool>("IsSuspended");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<string>("MemberId")
+                        .IsRequired();
+
+                    b.Property<string>("MiddleName");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.HasKey("__ID");
+
+                    b.ToTable("UserAccounts");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.Waiver", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("MemberId");
+
+                    b.Property<DateTimeOffset>("SignedOn");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.HasKey("__ID");
+
+                    b.HasIndex("MemberId");
+
+                    b.ToTable("Waivers");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.Certification", b =>
+                {
+                    b.HasOne("WAMA.Core.Models.DTOs.UserAccount", "Member")
+                        .WithMany("Certifications")
+                        .HasForeignKey("MemberId")
+                        .HasPrincipalKey("MemberId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.CheckInActivity", b =>
+                {
+                    b.HasOne("WAMA.Core.Models.DTOs.UserAccount", "Member")
+                        .WithMany("CheckInActivities")
+                        .HasForeignKey("MemberId")
+                        .HasPrincipalKey("MemberId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.LogInCredential", b =>
+                {
+                    b.HasOne("WAMA.Core.Models.DTOs.UserAccount", "Member")
+                        .WithOne("LogInCredential")
+                        .HasForeignKey("WAMA.Core.Models.DTOs.LogInCredential", "MemberId")
+                        .HasPrincipalKey("WAMA.Core.Models.DTOs.UserAccount", "MemberId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.Waiver", b =>
+                {
+                    b.HasOne("WAMA.Core.Models.DTOs.UserAccount", "Member")
+                        .WithMany("Waivers")
+                        .HasForeignKey("MemberId")
+                        .HasPrincipalKey("MemberId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+        }
+    }
+}

--- a/app/wama.core/Migrations/20170220045410_remove lastupdatedon.cs
+++ b/app/wama.core/Migrations/20170220045410_remove lastupdatedon.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WAMA.Core.Migrations
+{
+    public partial class removelastupdatedon : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "Waivers");
+
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "UserAccounts");
+
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "LogInCredentials");
+
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "CheckInActivities");
+
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "Certifications");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "Waivers",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "UserAccounts",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "LogInCredentials",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "CheckInActivities",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "Certifications",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+    }
+}

--- a/app/wama.core/Migrations/20170220050009_re-add lastupdateon.Designer.cs
+++ b/app/wama.core/Migrations/20170220050009_re-add lastupdateon.Designer.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using WAMA.Core.Models;
+using WAMA.Core.Models.DTOs;
+
+namespace WAMA.Core.Migrations
+{
+    [DbContext(typeof(WamaDbContext))]
+    [Migration("20170220050009_re-add lastupdateon")]
+    partial class readdlastupdateon
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.0-rtm-22752")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.Certification", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTimeOffset>("CertifiedOn");
+
+                    b.Property<DateTimeOffset>("ExpiresOn");
+
+                    b.Property<string>("MemberId");
+
+                    b.Property<int>("Type");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.Property<DateTimeOffset>("__LastUpdatedOn")
+                        .ValueGeneratedOnAddOrUpdate();
+
+                    b.HasKey("__ID");
+
+                    b.HasIndex("MemberId");
+
+                    b.ToTable("Certifications");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.CheckInActivity", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTimeOffset>("CheckInDateTime");
+
+                    b.Property<bool>("IsCheckedIn");
+
+                    b.Property<string>("MemberId");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.Property<DateTimeOffset>("__LastUpdatedOn")
+                        .ValueGeneratedOnAddOrUpdate();
+
+                    b.HasKey("__ID");
+
+                    b.HasIndex("MemberId");
+
+                    b.ToTable("CheckInActivities");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.LogInCredential", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("MemberId");
+
+                    b.Property<string>("Password");
+
+                    b.Property<bool>("RequiresPassword");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.Property<DateTimeOffset>("__LastUpdatedOn")
+                        .ValueGeneratedOnAddOrUpdate();
+
+                    b.HasKey("__ID");
+
+                    b.HasIndex("MemberId")
+                        .IsUnique();
+
+                    b.ToTable("LogInCredentials");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.UserAccount", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("AccountType");
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<int>("Gender");
+
+                    b.Property<bool>("HasBeenApproved");
+
+                    b.Property<int>("InstitutionAffiliation");
+
+                    b.Property<bool>("IsSuspended");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<string>("MemberId")
+                        .IsRequired();
+
+                    b.Property<string>("MiddleName");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.Property<DateTimeOffset>("__LastUpdatedOn")
+                        .ValueGeneratedOnAddOrUpdate();
+
+                    b.HasKey("__ID");
+
+                    b.ToTable("UserAccounts");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.Waiver", b =>
+                {
+                    b.Property<int>("__ID")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("MemberId");
+
+                    b.Property<DateTimeOffset>("SignedOn");
+
+                    b.Property<DateTimeOffset>("__CreatedOn");
+
+                    b.Property<DateTimeOffset>("__LastUpdatedOn")
+                        .ValueGeneratedOnAddOrUpdate();
+
+                    b.HasKey("__ID");
+
+                    b.HasIndex("MemberId");
+
+                    b.ToTable("Waivers");
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.Certification", b =>
+                {
+                    b.HasOne("WAMA.Core.Models.DTOs.UserAccount", "Member")
+                        .WithMany("Certifications")
+                        .HasForeignKey("MemberId")
+                        .HasPrincipalKey("MemberId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.CheckInActivity", b =>
+                {
+                    b.HasOne("WAMA.Core.Models.DTOs.UserAccount", "Member")
+                        .WithMany("CheckInActivities")
+                        .HasForeignKey("MemberId")
+                        .HasPrincipalKey("MemberId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.LogInCredential", b =>
+                {
+                    b.HasOne("WAMA.Core.Models.DTOs.UserAccount", "Member")
+                        .WithOne("LogInCredential")
+                        .HasForeignKey("WAMA.Core.Models.DTOs.LogInCredential", "MemberId")
+                        .HasPrincipalKey("WAMA.Core.Models.DTOs.UserAccount", "MemberId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("WAMA.Core.Models.DTOs.Waiver", b =>
+                {
+                    b.HasOne("WAMA.Core.Models.DTOs.UserAccount", "Member")
+                        .WithMany("Waivers")
+                        .HasForeignKey("MemberId")
+                        .HasPrincipalKey("MemberId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+        }
+    }
+}

--- a/app/wama.core/Migrations/20170220050009_re-add lastupdateon.cs
+++ b/app/wama.core/Migrations/20170220050009_re-add lastupdateon.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WAMA.Core.Migrations
+{
+    public partial class readdlastupdateon : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "Waivers",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "UserAccounts",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "LogInCredentials",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "CheckInActivities",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "__LastUpdatedOn",
+                table: "Certifications",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "Waivers");
+
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "UserAccounts");
+
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "LogInCredentials");
+
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "CheckInActivities");
+
+            migrationBuilder.DropColumn(
+                name: "__LastUpdatedOn",
+                table: "Certifications");
+        }
+    }
+}


### PR DESCRIPTION
For some reason, when these migration histories was being generated, some of the tables didn't have the default value for the _LastUpdatedOn set. Hence resulting in errors while inserting new records.

I just commented and uncommented that property in the TableRow table. At each step, generate a new migration history.